### PR TITLE
use full module name for data_manipulation

### DIFF
--- a/mlfromscratch/utils/optimizers.py
+++ b/mlfromscratch/utils/optimizers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from data_manipulation import make_diagonal, normalize
+from mlfromscratch.utils.data_manipulation import make_diagonal, normalize
 
 # Optimizers for models that use gradient methods for finding the 
 # weights that minimizes the loss.


### PR DESCRIPTION
Hey Erik,

I have to change the name before running 'python setup.py install' to make some examples work. I'm new to python, so feel free to close this PR and let me know if I missed something, thanks.

FYI, I'm using python3 and on a Mac.