### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ but rather to present the inner workings of them in a transparent and accessible
     $ cd ML-From-Scratch
     $ python setup.py install
 
+if you are getting an error like "RuntimeError: Python version >= 3.5 required." then install python3 ( if not installed ), and run this command instead of last command given before;
+
+    $ python3 setup.py install
+
+
 ## Examples
 ### Polynomial Regression
     $ python mlfromscratch/examples/polynomial_regression.py


### PR DESCRIPTION
Explaining added for python3. The script does not be installed if you run it with pytonh3.x. Most OSs (including Ubuntu and MacOSX) comes with python2.x and trying to removing python2.x is so dangerous because OS uses python2.x itself.