### PR TITLE
transposed V from svd in LinearRegression

### DIFF
--- a/mlfromscratch/supervised_learning/regression.py
+++ b/mlfromscratch/supervised_learning/regression.py
@@ -110,7 +110,7 @@ class LinearRegression(Regression):
             # Calculate weights by least squares (using Moore-Penrose pseudoinverse)
             U, S, V = np.linalg.svd(X.T.dot(X))
             S = np.diag(S)
-            X_sq_reg_inv = V.dot(np.linalg.pinv(S)).dot(U.T)
+            X_sq_reg_inv = V.T.dot(np.linalg.pinv(S)).dot(U.T)
             self.w = X_sq_reg_inv.dot(X.T).dot(y)
         else:
             super(LinearRegression, self).fit(X, y)


### PR DESCRIPTION
There's a mistake in the LinearRegression module.  

You use the Moore-Penrose pseudoinverse on the values returned from np.linalg.svd().

However, the values returned from Numpy's svd module are not the ones returned by traditional SVD.

Normal SVD reduces to A = U @ S @ V.T, but Numpy's implementation is A = U @ S @ V.

Basically, the V returned by Numpy's SVD is actually V.T.  

However, when you implement the pseudoinverse you use this line:

X_sq_reg_inv = V.dot(np.linalg.pinv(S)).dot(U.T).

That's the doctrinaire way of the SVD-based pseudoinverse, but you need to transpose V here in order to get the correct results.

I can provide more detail to demonstrate how this returns correct results, but right now your LinearRegression isn't correct as is.