### PR TITLE
dbscan get_neighbors fix

### DIFF
--- a/mlfromscratch/examples/dbscan.py
+++ b/mlfromscratch/examples/dbscan.py
@@ -17,6 +17,8 @@ def main():
     clf = DBSCAN(eps=0.17, min_samples=5)
     y_pred = clf.predict(X)
 
+    print('cluster count:', len(set(y_pred)))
+
     # Project the data onto the 2 primary principal components
     p = Plot()
     p.plot_in_2d(X, y_pred, title="DBSCAN")

--- a/mlfromscratch/unsupervised_learning/dbscan.py
+++ b/mlfromscratch/unsupervised_learning/dbscan.py
@@ -24,8 +24,9 @@ class DBSCAN():
         A sample_2 is considered a neighbor of sample_1 if the distance between
         them is smaller than epsilon """
         neighbors = []
-        idxs = np.arange(len(self.X))
-        for i, _sample in enumerate(self.X[idxs != sample_i]):
+        for i, _sample in enumerate(self.X):
+            if i == sample_i:
+                continue
             distance = euclidean_distance(self.X[sample_i], _sample)
             if distance < self.eps:
                 neighbors.append(i)


### PR DESCRIPTION
`i` is off by one for indexes after `sample_i`

**Before**

![before](https://user-images.githubusercontent.com/191903/70365961-f710b280-1848-11ea-8a91-9ca3a5286c89.png)

Cluster count: 4-6

**After**

![after](https://user-images.githubusercontent.com/191903/70365965-fbd56680-1848-11ea-83e3-7c90966d4c30.png)

Cluster count: 2-3