### PR TITLE
docs: fix simple typo, sampels -> samples

### DIFF
--- a/mlfromscratch/supervised_learning/xgboost.py
+++ b/mlfromscratch/supervised_learning/xgboost.py
@@ -55,7 +55,7 @@ class XGBoost(object):
                  min_impurity=1e-7, max_depth=2):
         self.n_estimators = n_estimators            # Number of trees
         self.learning_rate = learning_rate          # Step size for weight update
-        self.min_samples_split = min_samples_split  # The minimum n of sampels to justify split
+        self.min_samples_split = min_samples_split  # The minimum n of samples to justify split
         self.min_impurity = min_impurity              # Minimum variance reduction to continue
         self.max_depth = max_depth                  # Maximum depth for tree
 


### PR DESCRIPTION
There is a small typo in mlfromscratch/supervised_learning/xgboost.py.

Should read `samples` rather than `sampels`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md