### PR TITLE
(dbscan) Use valid index for neighbors

### DIFF
--- a/mlfromscratch/unsupervised_learning/dbscan.py
+++ b/mlfromscratch/unsupervised_learning/dbscan.py
@@ -24,8 +24,9 @@ class DBSCAN():
         A sample_2 is considered a neighbor of sample_1 if the distance between
         them is smaller than epsilon """
         neighbors = []
-        idxs = np.arange(len(self.X))
-        for i, _sample in enumerate(self.X[idxs != sample_i]):
+        for i, _sample in enumerate(self.X):
+            if i == sample_i:
+                continue
             distance = euclidean_distance(self.X[sample_i], _sample)
             if distance < self.eps:
                 neighbors.append(i)


### PR DESCRIPTION
The DBSCAN implementation was producing garbage results for me because the `_get_neighbors` function was returning the wrong indices for valid neighbors.

If comparing a sample with higher index than the argument, the returned indices were off by 1.

This change fixes it.

PS thanks for this implementation! It's a better fit for my use-case, where speed is not important but avoiding `scipy` is very convenient.