### PR TITLE
Bug fix, use L1-norm instead of L2-norm for L1 regularization

### DIFF
--- a/mlfromscratch/supervised_learning/regression.py
+++ b/mlfromscratch/supervised_learning/regression.py
@@ -9,7 +9,7 @@ class l1_regularization():
         self.alpha = alpha
     
     def __call__(self, w):
-        return self.alpha * np.linalg.norm(w)
+        return self.alpha * np.linalg.norm(w, 1)
 
     def grad(self, w):
         return self.alpha * np.sign(w)


### PR DESCRIPTION
The default norm for `np.linalg.norm` is the Frobenius norm or L2-norm. This needs to change to the L1 norm (Manhattan) to be correct.

PS. This project is somewhat abandoned it seems, but I think it makes sense to have a PR for other people looking for things that might be incorrect. I spent some time trying to figure this one out :P 