### PR TITLE
Changed sklearn to scikit-learn in requirements.txt file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 numpy
-sklearn
+scikit-learn
 pandas
 cvxopt
 scipy


### PR DESCRIPTION
Closes #109 
Simply changed the name of the package from `sklearn` to `scikit-learn` in the `requirements.txt` file.