### PR TITLE
Remove useless (and wrong) import of class SquareLoss.

### DIFF
--- a/mlfromscratch/examples/gradient_boosting_regressor.py
+++ b/mlfromscratch/examples/gradient_boosting_regressor.py
@@ -2,11 +2,9 @@ from __future__ import division, print_function
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-import progressbar
 
 from mlfromscratch.utils import train_test_split, standardize, to_categorical
 from mlfromscratch.utils import mean_squared_error, accuracy_score, Plot
-from mlfromscratch.utils.loss_functions import SquareLoss
 from mlfromscratch.utils.misc import bar_widgets
 from mlfromscratch.supervised_learning import GradientBoostingRegressor
 


### PR DESCRIPTION
Closes #111

This PR fixes the issue described in issue #111, where the class `SquareLoss` was imported but not used, and the import was from an incorrect path, causing errors.

