### PR TITLE
Fix deprecated sklearn fetch_mldata import

### DIFF
--- a/mlfromscratch/unsupervised_learning/generative_adversarial_network.py
+++ b/mlfromscratch/unsupervised_learning/generative_adversarial_network.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import progressbar
 
-from sklearn.datasets import fetch_mldata
+from sklearn.datasets import fetch_openml
 
 from mlfromscratch.deep_learning.optimizers import Adam
 from mlfromscratch.deep_learning.loss_functions import CrossEntropy
@@ -78,7 +78,7 @@ class GAN():
 
     def train(self, n_epochs, batch_size=128, save_interval=50):
 
-        mnist = fetch_mldata('MNIST original')
+        mnist = fetch_openml('mnist_784', version=1, as_frame=False)
 
         X = mnist.data
         y = mnist.target


### PR DESCRIPTION
## Problem
The `generative_adversarial_network.py` script fails to run due to a deprecated import:

## Error: 
ImportError: cannot import name 'fetch_mldata' from 'sklearn.datasets'
`fetch_mldata` was deprecated in scikit-learn 0.20 and removed in scikit-learn 1.2.

## Solution
- Replaced `fetch_mldata` with `fetch_openml` for MNIST data loading
- Updated the function call to use `'mnist_784'` dataset with `version=1` and `as_frame=False` parameters
- This maintains the same data structure and functionality while using the modern API

## Testing
- [x] Script imports successfully
- [x] GAN initialises without errors
- [x] Training runs successfully with the new data loading method
- [x] Data format remains compatible with existing code

## Changes
- Line 8: `from sklearn.datasets import fetch_mldata` → `from sklearn.datasets import fetch_openml`
- Line 81: `mnist = fetch_mldata('MNIST original')` → `mnist = fetch_openml('mnist_784', version=1, as_frame=False)`

This fix ensures compatibility with modern scikit-learn versions while maintaining backward compatibility with the existing codebase.

