### PR TITLE
Fix missing 1/n_samples factor in LogisticRegression gradient update

### DIFF
--- a/mlfromscratch/supervised_learning/logistic_regression.py
+++ b/mlfromscratch/supervised_learning/logistic_regression.py
@@ -37,7 +37,7 @@ class LogisticRegression():
             if self.gradient_descent:
                 # Move against the gradient of the loss function with
                 # respect to the parameters to minimize the loss
-                self.param -= self.learning_rate * -(y - y_pred).dot(X)
+                self.param -= self.learning_rate * (-(y - y_pred).dot(X) / X.shape[0])
             else:
                 # Make a diagonal matrix of the sigmoid gradient column vector
                 diag_gradient = make_diagonal(self.sigmoid.gradient(X.dot(self.param)))


### PR DESCRIPTION
This PR fixes the gradient update in LogisticRegression. The original code was missing the division by the number of samples (1/n), causing incorrect gradient scaling. This update makes the gradient consistent with standard logistic regression and the implementation in Regression.py.