### PR TITLE
Add docstring for SoftPlus activation

### DIFF
--- a/mlfromscratch/deep_learning/activation_functions.py
+++ b/mlfromscratch/deep_learning/activation_functions.py
@@ -67,8 +67,22 @@ class SELU():
         return self.scale * np.where(x >= 0.0, 1, self.alpha * np.exp(x))
 
 class SoftPlus():
+    """
+    SoftPlus activation function.
+    Smooth approximation of ReLU.
+
+    f(x) = log(1 + e^x)
+
+    Advantages:
+    - Differentiable everywhere
+    - Avoids dead neuron problem of ReLU
+    """
+
     def __call__(self, x):
         return np.log(1 + np.exp(x))
+
+    def gradient(self, x):
+        return 1 / (1 + np.exp(-x))
 
     def gradient(self, x):
         return 1 / (1 + np.exp(-x))

--- a/mlfromscratch/deep_learning/activation_functions.py
+++ b/mlfromscratch/deep_learning/activation_functions.py
@@ -84,6 +84,3 @@ class SoftPlus():
     def gradient(self, x):
         return 1 / (1 + np.exp(-x))
 
-    def gradient(self, x):
-        return 1 / (1 + np.exp(-x))
-


### PR DESCRIPTION
This PR adds a docstring for the SoftPlus activation class in mlfromscratch/deep_learning/activation_functions.py, describing the function, its formula (f(x) = log(1 + e^x)), and its advantages over ReLU
